### PR TITLE
Fix am pm LED indicator 

### DIFF
--- a/UserConfig.cmake
+++ b/UserConfig.cmake
@@ -28,4 +28,9 @@ add_compile_definitions(
     # accurate (a few seconds difference) but can help in case of difficulty synchronizing from GPS
     # indoors.
     # GPS_SYNC_WITHOUT_FIX
+
+    # This can be defined to use the RTC temperature calibration.
+    # The value is the temperature in degrees celsius at which the RTC is compensated.
+    # For example, set -2.0 for lowering 2.0 degrees celsius on the display.
+    RTC_TEMP_CALIB=0.0
 )

--- a/src/DaylightSavingTime.cpp
+++ b/src/DaylightSavingTime.cpp
@@ -67,9 +67,11 @@ void DaylightSavingTime::determineDstStartAndEnd(const tm &givenTm)
     tm dstEndTm = givenTm;
     if (DST_LOCATION == Europe)
     {
+        int offset_minutes = static_cast<int>(UTC_OFFSET * 60);
+
         // In Europe, DST starts on last Sunday in March at 01:00 UTC
         dstStartTm.tm_sec = 0;
-        dstStartTm.tm_min = UTC_OFFSET * 60 % 60;
+        dstStartTm.tm_min = (offset_minutes % 60 + 60) % 60;
         dstStartTm.tm_hour = 1 + UTC_OFFSET;
         dstStartTm.tm_mon = 2; // March as "months since January"
         dstStartTm.tm_mday = 31; // Last day of March
@@ -78,7 +80,7 @@ void DaylightSavingTime::determineDstStartAndEnd(const tm &givenTm)
 
         // In Europe, DST ends on last Sunday in October at 01:00 UTC
         dstEndTm.tm_sec = 0;
-        dstEndTm.tm_min = UTC_OFFSET * 60 % 60;
+        dstEndTm.tm_min = (offset_minutes % 60 + 60) % 60;
         dstEndTm.tm_hour = 1 + UTC_OFFSET;
         dstEndTm.tm_mon = 9; // October as "months since January"
         dstEndTm.tm_mday = 31; // Last day of October

--- a/src/DaylightSavingTime.cpp
+++ b/src/DaylightSavingTime.cpp
@@ -80,7 +80,7 @@ void DaylightSavingTime::determineDstStartAndEnd(const tm &givenTm)
 
         // In Europe, DST ends on last Sunday in October at 01:00 UTC
         dstEndTm.tm_sec = 0;
-        dstEndTm.tm_min = (ooffsetMinutes % 60) % 60;
+        dstEndTm.tm_min = (offsetMinutes % 60) % 60;
         dstEndTm.tm_hour = 1 + UTC_OFFSET;
         dstEndTm.tm_mon = 9; // October as "months since January"
         dstEndTm.tm_mday = 31; // Last day of October

--- a/src/DaylightSavingTime.cpp
+++ b/src/DaylightSavingTime.cpp
@@ -71,7 +71,7 @@ void DaylightSavingTime::determineDstStartAndEnd(const tm &givenTm)
 
         // In Europe, DST starts on last Sunday in March at 01:00 UTC
         dstStartTm.tm_sec = 0;
-        dstStartTm.tm_min = (offset_minutes % 60 + 60) % 60;
+        dstStartTm.tm_min = (offsetMinutes % 60 + 60) % 60;
         dstStartTm.tm_hour = 1 + UTC_OFFSET;
         dstStartTm.tm_mon = 2; // March as "months since January"
         dstStartTm.tm_mday = 31; // Last day of March
@@ -80,7 +80,7 @@ void DaylightSavingTime::determineDstStartAndEnd(const tm &givenTm)
 
         // In Europe, DST ends on last Sunday in October at 01:00 UTC
         dstEndTm.tm_sec = 0;
-        dstEndTm.tm_min = (offset_minutes % 60 + 60) % 60;
+        dstEndTm.tm_min = (ooffsetMinutes % 60) % 60;
         dstEndTm.tm_hour = 1 + UTC_OFFSET;
         dstEndTm.tm_mon = 9; // October as "months since January"
         dstEndTm.tm_mday = 31; // Last day of October

--- a/src/DaylightSavingTime.cpp
+++ b/src/DaylightSavingTime.cpp
@@ -67,7 +67,7 @@ void DaylightSavingTime::determineDstStartAndEnd(const tm &givenTm)
     tm dstEndTm = givenTm;
     if (DST_LOCATION == Europe)
     {
-        int offset_minutes = static_cast<int>(UTC_OFFSET * 60);
+        int offsetMinutes = static_cast<int>(UTC_OFFSET * 60);
 
         // In Europe, DST starts on last Sunday in March at 01:00 UTC
         dstStartTm.tm_sec = 0;

--- a/src/Functions/AbstractFunction.cpp
+++ b/src/Functions/AbstractFunction.cpp
@@ -27,8 +27,12 @@ Clock &AbstractFunction::clock()
 
 void AbstractFunction::convertHour(int hour24, int &displayedHour, bool &morning) const
 {
-    if (settings().format24h)
+    if (settings().format24h) {
         displayedHour = hour24;
+        // Although the AM/PM indicator is not displayed in 24h mode,
+        // 'morning' is initialized to prevent using an uninitialized value.
+        morning = hour24 < 12;
+    }
     else
     {
         morning = hour24 < 12;

--- a/src/Functions/AbstractFunction.cpp
+++ b/src/Functions/AbstractFunction.cpp
@@ -27,15 +27,14 @@ Clock &AbstractFunction::clock()
 
 void AbstractFunction::convertHour(int hour24, int &displayedHour, bool &morning) const
 {
+    // 'morning' is initialized to prevent using an uninitialized value.
+    morning = hour24 < 12;
+    
     if (settings().format24h) {
         displayedHour = hour24;
-        // Although the AM/PM indicator is not displayed in 24h mode,
-        // 'morning' is initialized to prevent using an uninitialized value.
-        morning = hour24 < 12;
     }
     else
     {
-        morning = hour24 < 12;
         displayedHour =  morning ? hour24 : hour24 - 12;
         
         if (displayedHour == 0)

--- a/src/Functions/Temperature.cpp
+++ b/src/Functions/Temperature.cpp
@@ -24,7 +24,7 @@ void Temperature::renderFrame(Bitmap &frame, int editedValueIndex, int blinkingC
     float temp = clock().rtc()->temperature();
 
     // RTC Temperature calibration 
-    temp = round(temp * 10)/10 + RTC_TEMP_CALIB;
+    temp += RTC_TEMP_CALIB;
 
     if (std::isnan(temp))
         return;

--- a/src/Functions/Temperature.cpp
+++ b/src/Functions/Temperature.cpp
@@ -23,6 +23,9 @@ void Temperature::renderFrame(Bitmap &frame, int editedValueIndex, int blinkingC
     TRACE << "Get temperature";
     float temp = clock().rtc()->temperature();
 
+    // RTC Temperature calibration 
+    temp = round(temp * 10)/10 + RTC_TEMP_CALIB;
+
     if (std::isnan(temp))
         return;
 


### PR DESCRIPTION
Bug fix on "pm" LED indicator,  from midnight to noon, for the 24-hour display setting. 